### PR TITLE
Base64.NO_WRAP flag set on Base64 encode.

### DIFF
--- a/src/org/sdf/danielsz/OAuthUtils.java
+++ b/src/org/sdf/danielsz/OAuthUtils.java
@@ -399,11 +399,11 @@ public class OAuthUtils {
 	public static String encodeCredentials(String username, String password) {
 		String cred = username + ":" + password;
 		String encodedValue = null;
-		byte[] encodedBytes = Base64.encode(cred.getBytes(), Base64.DEFAULT);
+		byte[] encodedBytes = Base64.encode(cred.getBytes(), Base64.NO_WRAP);
 		encodedValue = new String(encodedBytes);
 		System.out.println("encodedBytes " + new String(encodedBytes));
 
-		byte[] decodedBytes = Base64.decode(encodedBytes, Base64.DEFAULT);
+		byte[] decodedBytes = Base64.decode(encodedBytes, Base64.NO_WRAP);
 		System.out.println("decodedBytes " + new String(decodedBytes));
 
 		return encodedValue;


### PR DESCRIPTION
Base64.NO_WRAP flag set on Base64 encode. Otherwise newlines will break Authorization header. 
